### PR TITLE
Don't use underscores in Go names; var input_json_as_bytes should be inputJSONAsBytes

### DIFF
--- a/article_13/18_json_unmarshal_unknown_struct.go
+++ b/article_13/18_json_unmarshal_unknown_struct.go
@@ -17,18 +17,18 @@ import (
 )
 
 func main() {
-	input_json_as_bytes, err := ioutil.ReadFile("users_map_different_keys.json")
+	inputJSONAsBytes, err := ioutil.ReadFile("users_map_different_keys.json")
 	if err != nil {
 		log.Fatal(err)
 	}
 	fmt.Println("Input (bytes):")
-	fmt.Println(input_json_as_bytes)
+	fmt.Println(inputJSONAsBytes)
 
 	fmt.Println("\nInput (string):")
-	fmt.Println(string(input_json_as_bytes))
+	fmt.Println(string(inputJSONAsBytes))
 
 	m1 := map[string]interface{}{}
-	json.Unmarshal(input_json_as_bytes, &m1)
+	json.Unmarshal(inputJSONAsBytes, &m1)
 
 	fmt.Println("\nOutput:")
 	fmt.Println(m1)


### PR DESCRIPTION
Don't use underscores in Go names; var input_json_as_bytes should be inputJSONAsBytes