### PR TITLE
Don't use underscores in Go names; var input_json_as_bytes should be inputJSONAsBytes

### DIFF
--- a/article_13/17_json_unmarshal_map_of_struct_different_keys.go
+++ b/article_13/17_json_unmarshal_map_of_struct_different_keys.go
@@ -24,18 +24,18 @@ type User struct {
 }
 
 func main() {
-	input_json_as_bytes, err := ioutil.ReadFile("users_map_different_keys.json")
+	inputJSONAsBytes, err := ioutil.ReadFile("users_map_different_keys.json")
 	if err != nil {
 		log.Fatal(err)
 	}
 	fmt.Println("Input (bytes):")
-	fmt.Println(input_json_as_bytes)
+	fmt.Println(inputJSONAsBytes)
 
 	fmt.Println("\nInput (string):")
-	fmt.Println(string(input_json_as_bytes))
+	fmt.Println(string(inputJSONAsBytes))
 
 	m1 := map[string]User{}
-	json.Unmarshal(input_json_as_bytes, &m1)
+	json.Unmarshal(inputJSONAsBytes, &m1)
 
 	fmt.Println("\nOutput:")
 	fmt.Println(m1)


### PR DESCRIPTION
Don't use underscores in Go names; var input_json_as_bytes should be inputJSONAsBytes